### PR TITLE
Buffer overflow in command buffer in function cli()

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ XFS Interface (eXperimental File System) is an external interface to access the 
 
 Installation
 
-Prerequisites :
+Prerequisites 
 -------------
 	• GCC (GNU project C and C++ compiler)
 

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 XFS Interface
 =============
 
-Introduction 
+Introduction :
 XFS Interface (eXperimental File System) is an external interface to access the filesystem of the XOS. The filesystem is simulated on a binary file called ”disk.xfs”. The interface can format the disk, load/remove files, list files and copy blocks to a UNIX file.
 
 

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 XFS Interface
 =============
 
-Introduction :
+Introduction 
 XFS Interface (eXperimental File System) is an external interface to access the filesystem of the XOS. The filesystem is simulated on a binary file called ”disk.xfs”. The interface can format the disk, load/remove files, list files and copy blocks to a UNIX file.
 
 

--- a/README
+++ b/README
@@ -7,7 +7,7 @@ XFS Interface (eXperimental File System) is an external interface to access the 
 
 Installation
 
-Prerequisites 
+Prerequisites :
 -------------
 	• GCC (GNU project C and C++ compiler)
 

--- a/interface.c
+++ b/interface.c
@@ -302,7 +302,17 @@ int main(int argc, char **argv){
 		loadFileToVirtualDisk();
 	}
 	close(fd);
-		
+	
+	if(argc > 1)
+	{
+		if(strlen(argv[1]) >= 100)
+		{
+			printf("Length of argument exceeds command buffer\n");
+			printf("Fatal Error\n");
+			return 1;
+		}
+	}				
+						
 	cli(argc, argv);					//Loads the Command Line Interface
 	return 0;
 }


### PR DESCRIPTION
The strcpy function in cli does not check the length of the string in the argv[1] buffer, leading to a stack buffer overflow. 
